### PR TITLE
Fix email links and correct news date and footer script path

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,7 +1,7 @@
 - date: 1 Jan 2026
   headline: Welcome Captain White to join the team as a MPhil student. 
 
-- date: 1 Oct 2026
+- date: 1 Oct 2025
   headline: Glad to share that we have secured a NSW DIN Pilot project focusing on UAV navigation in GNSS-denied environment together with Macquarie University.
 
 - date: 1 Jul 2024

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,4 +28,4 @@
 </div>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-<script src="{{ site.url }}{{ boyangli.com }}/js/bootstrap.min.js"></script>
+<script src="{{ site.url }}{{ site.baseurl }}/js/bootstrap.min.js"></script>

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -25,7 +25,7 @@ permalink: /team/
 <div class="col-sm-6 clearfix">
   <img src="{{ site.url }}{{ site.baseurl }}/images/teampic/{{ member.photo }}" class="img-responsive" width="25%" style="float: left" />
   <h4>{{ member.name }}</h4>
-  <i>{{ member.info }}<br>email: <{{ member.email }}></i>
+  <i>{{ member.info }}<br>email: <a href="mailto:{{ member.email }}">{{ member.email }}</a></i>
   <ul style="overflow: hidden">
 
   {% if member.number_educ == 1 %}
@@ -88,7 +88,7 @@ permalink: /team/
   <img src="{{ site.url }}{{ site.baseurl }}/images/teampic/{{ member.photo }}" class="img-responsive" width="25%" style="float: left" />
 
   <h4>{{ member.name }}</h4>
-  <i>{{ member.info }}<br>email: <{{ member.email }}></i>
+  <i>{{ member.info }}<br>email: <a href="mailto:{{ member.email }}">{{ member.email }}</a></i>
   <ul style="overflow: hidden">
 
   {% if member.number_educ == 1 %}
@@ -143,7 +143,7 @@ permalink: /team/
   <img src="{{ site.url }}{{ site.baseurl }}/images/teampic/{{ member.photo }}" class="img-responsive" width="25%" style="float: left" />
   
   <h4>{{ member.name }}</h4>
-  <i>{{ member.info }}<br>email: <{{ member.email }}></i>
+  <i>{{ member.info }}<br>email: <a href="mailto:{{ member.email }}">{{ member.email }}</a></i>
   <ul style="overflow: hidden">
 
   {% if member.number_educ == 1 %}


### PR DESCRIPTION
## Summary
This PR fixes several issues in the team page template, news data, and footer configuration to improve functionality and correct errors.

## Key Changes
- **Email links**: Convert plain text email addresses to clickable mailto links in team member profiles across three sections (lines 28, 91, and 146 in `_pages/team.md`)
- **News date correction**: Fix incorrect year in news entry from "1 Oct 2026" to "1 Oct 2025" in `_data/news.yml`
- **Footer script path**: Correct malformed variable reference in bootstrap script path from `{{ boyangli.com }}` to `{{ site.baseurl }}` in `_includes/footer.html`

## Implementation Details
- Email addresses are now wrapped in proper HTML anchor tags with `mailto:` protocol, making them clickable for users
- The news date correction aligns the entry with the correct timeline (2025 instead of future 2026)
- The footer script path fix ensures the bootstrap JavaScript file is loaded from the correct relative path using the proper Jekyll site variable

https://claude.ai/code/session_01YYnnk9BjLt6etwVHTfSXCp